### PR TITLE
refactor(parser): migrate to web-tree-sitter WASM bindings

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,9 +19,8 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
-    "tree-sitter": "^0.25.0",
-    "tree-sitter-ruby": "^0.23.1",
-    "tree-sitter-typescript": "^0.23.2"
+    "@repomix/tree-sitter-wasms": "^0.1.16",
+    "web-tree-sitter": "^0.26.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13"

--- a/packages/core/src/parser/__tests__/parser.test.ts
+++ b/packages/core/src/parser/__tests__/parser.test.ts
@@ -14,17 +14,18 @@ describe('CodeParser', () => {
   });
 
   describe('getSupportedLanguages', () => {
-    it('returns typescript and ruby', () => {
+    it('returns typescript, tsx, and ruby', () => {
       const languages = parser.getSupportedLanguages();
       expect(languages).toContain('typescript');
+      expect(languages).toContain('tsx');
       expect(languages).toContain('ruby');
     });
   });
 
   describe('parse TypeScript', () => {
-    it('parses TypeScript code successfully', () => {
+    it('parses TypeScript code successfully', async () => {
       const code = 'function hello() { return "world"; }';
-      const result = parser.parse(code, 'typescript');
+      const result = await parser.parse(code, 'typescript');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -34,13 +35,13 @@ describe('CodeParser', () => {
       }
     });
 
-    it('extracts function declarations', () => {
+    it('extracts function declarations', async () => {
       const code = `
         function greet(name: string): string {
           return "Hello, " + name;
         }
       `;
-      const result = parser.parse(code, 'typescript');
+      const result = await parser.parse(code, 'typescript');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -51,7 +52,7 @@ describe('CodeParser', () => {
       }
     });
 
-    it('extracts class declarations', () => {
+    it('extracts class declarations', async () => {
       const code = `
         class Calculator {
           add(a: number, b: number): number {
@@ -59,7 +60,7 @@ describe('CodeParser', () => {
           }
         }
       `;
-      const result = parser.parse(code, 'typescript');
+      const result = await parser.parse(code, 'typescript');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -72,9 +73,9 @@ describe('CodeParser', () => {
   });
 
   describe('parse Ruby', () => {
-    it('parses Ruby code successfully', () => {
+    it('parses Ruby code successfully', async () => {
       const code = 'def hello; "world"; end';
-      const result = parser.parse(code, 'ruby');
+      const result = await parser.parse(code, 'ruby');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -83,13 +84,13 @@ describe('CodeParser', () => {
       }
     });
 
-    it('extracts method definitions', () => {
+    it('extracts method definitions', async () => {
       const code = `
         def greet(name)
           "Hello, #{name}!"
         end
       `;
-      const result = parser.parse(code, 'ruby');
+      const result = await parser.parse(code, 'ruby');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -100,7 +101,7 @@ describe('CodeParser', () => {
       }
     });
 
-    it('extracts class definitions', () => {
+    it('extracts class definitions', async () => {
       const code = `
         class Calculator
           def add(a, b)
@@ -108,7 +109,7 @@ describe('CodeParser', () => {
           end
         end
       `;
-      const result = parser.parse(code, 'ruby');
+      const result = await parser.parse(code, 'ruby');
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -124,9 +125,9 @@ describe('CodeParser', () => {
   });
 
   describe('parseFile', () => {
-    it('parses TypeScript file', () => {
+    it('parses TypeScript file', async () => {
       const filePath = join(fixturesDir, 'sample.ts');
-      const result = parser.parseFile(filePath);
+      const result = await parser.parseFile(filePath);
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -139,9 +140,9 @@ describe('CodeParser', () => {
       }
     });
 
-    it('parses Ruby file', () => {
+    it('parses Ruby file', async () => {
       const filePath = join(fixturesDir, 'sample.rb');
-      const result = parser.parseFile(filePath);
+      const result = await parser.parseFile(filePath);
 
       expect(result.success).toBe(true);
       if (result.success) {
@@ -154,8 +155,8 @@ describe('CodeParser', () => {
       }
     });
 
-    it('returns error for unsupported file type', () => {
-      const result = parser.parseFile('test.unknown');
+    it('returns error for unsupported file type', async () => {
+      const result = await parser.parseFile('test.unknown');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -163,8 +164,8 @@ describe('CodeParser', () => {
       }
     });
 
-    it('returns error for non-existent file', () => {
-      const result = parser.parseFile('/nonexistent/path/file.ts');
+    it('returns error for non-existent file', async () => {
+      const result = await parser.parseFile('/nonexistent/path/file.ts');
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -175,9 +176,9 @@ describe('CodeParser', () => {
   });
 
   describe('handles syntax errors gracefully', () => {
-    it('parses code with syntax errors without throwing', () => {
+    it('parses code with syntax errors without throwing', async () => {
       const brokenCode = 'function { broken syntax';
-      const result = parser.parse(brokenCode, 'typescript');
+      const result = await parser.parse(brokenCode, 'typescript');
 
       // Tree-sitter still produces a tree, just with error nodes
       expect(result.success).toBe(true);
@@ -191,7 +192,10 @@ describe('CodeParser', () => {
 describe('detectLanguage', () => {
   it('detects TypeScript files', () => {
     expect(detectLanguage('file.ts')).toBe('typescript');
-    expect(detectLanguage('file.tsx')).toBe('typescript');
+  });
+
+  it('detects TSX files', () => {
+    expect(detectLanguage('file.tsx')).toBe('tsx');
   });
 
   it('detects Ruby files', () => {
@@ -209,6 +213,7 @@ describe('getSupportedLanguages', () => {
     const languages = getSupportedLanguages();
     expect(Array.isArray(languages)).toBe(true);
     expect(languages).toContain('typescript');
+    expect(languages).toContain('tsx');
     expect(languages).toContain('ruby');
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,18 +32,15 @@ importers:
 
   packages/core:
     dependencies:
+      '@repomix/tree-sitter-wasms':
+        specifier: ^0.1.16
+        version: 0.1.16
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
-      tree-sitter:
-        specifier: ^0.25.0
-        version: 0.25.0
-      tree-sitter-ruby:
-        specifier: ^0.23.1
-        version: 0.23.1(tree-sitter@0.25.0)
-      tree-sitter-typescript:
-        specifier: ^0.23.2
-        version: 0.23.2(tree-sitter@0.25.0)
+      web-tree-sitter:
+        specifier: ^0.26.3
+        version: 0.26.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -283,6 +280,9 @@ packages:
   '@npmcli/fs@5.0.0':
     resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@repomix/tree-sitter-wasms@0.1.16':
+    resolution: {integrity: sha512-CIINozBWFwjhH4DQALN/b4n1S08fHhXQOdjX2G7s4w+Urew37aLU0AHVyCjHM5Pbnh63tDYt4YyUkS6vRUV38A==}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
@@ -974,14 +974,6 @@ packages:
     resolution: {integrity: sha512-sn9Et4N3ynsetj3spsZR729DVlGH6iBG4RiDMV7HEp3guyOW6W3S0unGpLDxT50mXortGUMax/ykUNQXdqc/Xg==}
     engines: {node: '>=10'}
 
-  node-addon-api@8.5.0:
-    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
-    engines: {node: ^18 || ^20 || >= 21}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
   node-gyp@12.1.0:
     resolution: {integrity: sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -1195,33 +1187,6 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  tree-sitter-javascript@0.23.1:
-    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
-    peerDependencies:
-      tree-sitter: ^0.21.1
-    peerDependenciesMeta:
-      tree-sitter:
-        optional: true
-
-  tree-sitter-ruby@0.23.1:
-    resolution: {integrity: sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==}
-    peerDependencies:
-      tree-sitter: ^0.21.1
-    peerDependenciesMeta:
-      tree-sitter:
-        optional: true
-
-  tree-sitter-typescript@0.23.2:
-    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
-    peerDependencies:
-      tree-sitter: ^0.21.0
-    peerDependenciesMeta:
-      tree-sitter:
-        optional: true
-
-  tree-sitter@0.25.0:
-    resolution: {integrity: sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==}
-
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -1336,6 +1301,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-tree-sitter@0.26.3:
+    resolution: {integrity: sha512-JIVgIKFS1w6lejxSntCtsS/QsE/ecTS00en809cMxMPxaor6MvUnQ+ovG8uTTTvQCFosSh4MeDdI5bSGw5SoBw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1532,6 +1500,8 @@ snapshots:
   '@npmcli/fs@5.0.0':
     dependencies:
       semver: 7.7.3
+
+  '@repomix/tree-sitter-wasms@0.1.16': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
@@ -2229,10 +2199,6 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  node-addon-api@8.5.0: {}
-
-  node-gyp-build@4.8.4: {}
-
   node-gyp@12.1.0:
     dependencies:
       env-paths: 2.2.1
@@ -2483,33 +2449,6 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tree-sitter-javascript@0.23.1(tree-sitter@0.25.0):
-    dependencies:
-      node-addon-api: 8.5.0
-      node-gyp-build: 4.8.4
-    optionalDependencies:
-      tree-sitter: 0.25.0
-
-  tree-sitter-ruby@0.23.1(tree-sitter@0.25.0):
-    dependencies:
-      node-addon-api: 8.5.0
-      node-gyp-build: 4.8.4
-    optionalDependencies:
-      tree-sitter: 0.25.0
-
-  tree-sitter-typescript@0.23.2(tree-sitter@0.25.0):
-    dependencies:
-      node-addon-api: 8.5.0
-      node-gyp-build: 4.8.4
-      tree-sitter-javascript: 0.23.1(tree-sitter@0.25.0)
-    optionalDependencies:
-      tree-sitter: 0.25.0
-
-  tree-sitter@0.25.0:
-    dependencies:
-      node-addon-api: 8.5.0
-      node-gyp-build: 4.8.4
-
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -2624,6 +2563,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  web-tree-sitter@0.26.3: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace native tree-sitter bindings with web-tree-sitter WASM to fix Node.js 24 compatibility
- Native bindings fail to compile due to V8 API changes in Node 24
- Make parser API async (WASM requires async initialization)
- Add TSX as separate language

## Test plan
- [x] All 77 tests pass on Node 24.11.1
- [x] Build succeeds
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)