### PR TITLE
feat(parser): enhance Ruby parameter extraction for advanced types

### DIFF
--- a/packages/core/src/parser/extractors/__tests__/ruby.test.ts
+++ b/packages/core/src/parser/extractors/__tests__/ruby.test.ts
@@ -97,6 +97,114 @@ describe('RubyExtractor', () => {
         methodType: 'instance',
       });
     });
+
+    it('extracts methods with optional parameters (default values)', async () => {
+      const code = `
+        def foo(bar = 1)
+          bar * 2
+        end
+      `;
+
+      const entities = await extractEntities(code);
+      const methods = entities.filter((e) => e.type === 'method');
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.name).toBe('foo');
+      expect(methods[0]?.metadata).toEqual({
+        parameters: ['bar = 1'],
+        methodType: 'instance',
+      });
+    });
+
+    it('extracts methods with keyword parameters', async () => {
+      const code = `
+        def foo(bar:, baz: 1)
+          bar + baz
+        end
+      `;
+
+      const entities = await extractEntities(code);
+      const methods = entities.filter((e) => e.type === 'method');
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.name).toBe('foo');
+      expect(methods[0]?.metadata).toEqual({
+        parameters: ['bar:', 'baz: 1'],
+        methodType: 'instance',
+      });
+    });
+
+    it('extracts methods with splat parameters', async () => {
+      const code = `
+        def foo(*args)
+          args.sum
+        end
+      `;
+
+      const entities = await extractEntities(code);
+      const methods = entities.filter((e) => e.type === 'method');
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.name).toBe('foo');
+      expect(methods[0]?.metadata).toEqual({
+        parameters: ['*args'],
+        methodType: 'instance',
+      });
+    });
+
+    it('extracts methods with hash splat parameters', async () => {
+      const code = `
+        def foo(**kwargs)
+          kwargs.keys
+        end
+      `;
+
+      const entities = await extractEntities(code);
+      const methods = entities.filter((e) => e.type === 'method');
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.name).toBe('foo');
+      expect(methods[0]?.metadata).toEqual({
+        parameters: ['**kwargs'],
+        methodType: 'instance',
+      });
+    });
+
+    it('extracts methods with block parameters', async () => {
+      const code = `
+        def foo(&block)
+          block.call
+        end
+      `;
+
+      const entities = await extractEntities(code);
+      const methods = entities.filter((e) => e.type === 'method');
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.name).toBe('foo');
+      expect(methods[0]?.metadata).toEqual({
+        parameters: ['&block'],
+        methodType: 'instance',
+      });
+    });
+
+    it('extracts methods with mixed advanced parameter types', async () => {
+      const code = `
+        def foo(a, b = 2, *args, c:, d: 3, **kwargs, &block)
+          block.call(a, b, args, c, d, kwargs)
+        end
+      `;
+
+      const entities = await extractEntities(code);
+      const methods = entities.filter((e) => e.type === 'method');
+
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.name).toBe('foo');
+      expect(methods[0]?.metadata).toEqual({
+        parameters: ['a', 'b = 2', '*args', 'c:', 'd: 3', '**kwargs', '&block'],
+        methodType: 'instance',
+      });
+    });
   });
 
   describe('class extraction', () => {

--- a/packages/core/src/parser/extractors/ruby.ts
+++ b/packages/core/src/parser/extractors/ruby.ts
@@ -146,8 +146,24 @@ export class RubyExtractor {
     const paramsNode = node.childForFieldName('parameters');
     if (!paramsNode) return [];
 
+    // Handle all Ruby parameter types:
+    // - identifier: simple positional (foo)
+    // - optional_parameter: default values (bar = 1)
+    // - keyword_parameter: keyword args (bar:, baz: 1)
+    // - splat_parameter: *args
+    // - hash_splat_parameter: **kwargs
+    // - block_parameter: &block
+    const validParamTypes = [
+      'identifier',
+      'optional_parameter',
+      'keyword_parameter',
+      'splat_parameter',
+      'hash_splat_parameter',
+      'block_parameter',
+    ];
+
     return paramsNode.children
-      .filter((child) => child.type === 'identifier')
+      .filter((child) => validParamTypes.includes(child.type))
       .map((child) => child.text);
   }
 }


### PR DESCRIPTION
## Summary

Enhanced Ruby parser to extract all parameter types including optional parameters, keyword parameters, splat parameters, hash splat parameters, and block parameters. Previously, the parser only extracted required positional parameters.

## Changes

- Updated `extractParameters` method in `packages/core/src/parsers/ruby.ts` to handle 6 parameter node types:
  - `optional_parameter` - Parameters with default values
  - `keyword_parameter` - Keyword arguments with defaults
  - `splat_parameter` - Variable argument collection (*args)
  - `hash_splat_parameter` - Keyword argument collection (**kwargs)
  - `block_parameter` - Block arguments (&block)
  - `identifier` - Standard required parameters (existing)
- Added comprehensive test coverage for all parameter types
- Added test case for mixed parameter types in single method

## Testing

- [x] Tests pass: `pnpm test` (400 passing)
- [x] Types pass: `pnpm typecheck`
- [x] Lint passes: `pnpm lint`
- [x] Build passes: `pnpm build`

## Test Coverage

6 new test cases added:
1. Optional parameters (`arg = value`)
2. Keyword parameters (`key: value`)
3. Splat parameters (`*args`)
4. Hash splat parameters (`**kwargs`)
5. Block parameters (`&block`)
6. Mixed parameters (all types in one method)

Closes #92