### PR TITLE
feat(parser): extract Ruby attribute accessors as method entities

### DIFF
--- a/packages/core/src/parser/extractors/__tests__/ruby.test.ts
+++ b/packages/core/src/parser/extractors/__tests__/ruby.test.ts
@@ -542,11 +542,11 @@ end`;
 
       expect(methods).toHaveLength(3);
       expect(methods[0]?.name).toBe('Product#id');
-      expect(methods[0]?.metadata?.methodType).toBe('getter');
+      expect(methods[0]?.metadata?.['methodType']).toBe('getter');
       expect(methods[1]?.name).toBe('Product#name');
-      expect(methods[1]?.metadata?.methodType).toBe('getter');
+      expect(methods[1]?.metadata?.['methodType']).toBe('getter');
       expect(methods[2]?.name).toBe('Product#price');
-      expect(methods[2]?.metadata?.methodType).toBe('getter');
+      expect(methods[2]?.metadata?.['methodType']).toBe('getter');
     });
 
     it('extracts multiple symbols from single attr_writer', async () => {
@@ -561,11 +561,11 @@ end`;
 
       expect(methods).toHaveLength(3);
       expect(methods[0]?.name).toBe('Product#a=');
-      expect(methods[0]?.metadata?.methodType).toBe('setter');
+      expect(methods[0]?.metadata?.['methodType']).toBe('setter');
       expect(methods[1]?.name).toBe('Product#b=');
-      expect(methods[1]?.metadata?.methodType).toBe('setter');
+      expect(methods[1]?.metadata?.['methodType']).toBe('setter');
       expect(methods[2]?.name).toBe('Product#c=');
-      expect(methods[2]?.metadata?.methodType).toBe('setter');
+      expect(methods[2]?.metadata?.['methodType']).toBe('setter');
     });
 
     it('extracts multiple symbols from single attr_accessor', async () => {
@@ -580,13 +580,13 @@ end`;
 
       expect(methods).toHaveLength(4); // 2 getters + 2 setters
       expect(methods[0]?.name).toBe('Product#x');
-      expect(methods[0]?.metadata?.methodType).toBe('getter');
+      expect(methods[0]?.metadata?.['methodType']).toBe('getter');
       expect(methods[1]?.name).toBe('Product#x=');
-      expect(methods[1]?.metadata?.methodType).toBe('setter');
+      expect(methods[1]?.metadata?.['methodType']).toBe('setter');
       expect(methods[2]?.name).toBe('Product#y');
-      expect(methods[2]?.metadata?.methodType).toBe('getter');
+      expect(methods[2]?.metadata?.['methodType']).toBe('getter');
       expect(methods[3]?.name).toBe('Product#y=');
-      expect(methods[3]?.metadata?.methodType).toBe('setter');
+      expect(methods[3]?.metadata?.['methodType']).toBe('setter');
     });
 
     it('builds correct qualified names inside class context', async () => {


### PR DESCRIPTION
## Summary

Added support for extracting Ruby attribute accessors (`attr_reader`, `attr_writer`, `attr_accessor`) as method entities in the code graph. These accessors now appear as proper getter/setter methods with correct naming conventions.

## Changes

- Added `extractAttrAccessorMethods()` function to Ruby extractor
- Detects `attr_reader`, `attr_writer`, `attr_accessor` calls in class bodies
- Creates method entities with appropriate naming:
  - `attr_reader :name` → getter method `name`
  - `attr_writer :name` → setter method `name=`
  - `attr_accessor :name` → both `name` and `name=`
- Added helper methods to RubyExtractionContext for cleaner code access
- Fixed TypeScript index signature access pattern
- Added 10 comprehensive test cases covering all accessor types

## Testing

- [x] Tests pass: `pnpm test` (447 tests total)
- [x] Types pass: `pnpm typecheck`
- [x] Lint passes: `pnpm lint`
- [x] Build passes: `pnpm build`

## Notes

This enhancement improves the completeness of Ruby class analysis by treating attribute accessors as the method entities they generate at runtime. This allows for more accurate call graph analysis and better understanding of Ruby class interfaces.

Closes #98