### PR TITLE
Export ts-morph parser from core package

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,14 @@ export {
   getSupportedLanguages,
   detectLanguage,
   getLanguageConfig,
+  parseProject,
+  extractEntities,
+  extractRelationships,
+  extractImportMap,
+  extractVueScript,
+  extractJsDocContent,
+  buildEntityLookupMap,
+  findBestMatch,
 } from './parser/index.js';
 export type {
   ParseResult,
@@ -23,6 +31,10 @@ export type {
   DirectoryParseOptions,
   DirectoryParseResult,
   FileParseResult,
+  ProjectParseOptions,
+  ProjectParseResult,
+  TsMorphEntity,
+  TsMorphRelationship,
 } from './parser/index.js';
 
 // Database exports

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -33,3 +33,23 @@ export type {
   DirectoryParseResult,
   FileParseResult,
 } from './directory-parser.js';
+
+// ts-morph parser exports
+export { parseProject } from './ts-morph-project-parser.js';
+export type {
+  ProjectParseOptions,
+  ProjectParseResult,
+} from './ts-morph-project-parser.js';
+export {
+  extractEntities,
+  extractRelationships,
+  extractImportMap,
+  extractVueScript,
+  extractJsDocContent,
+  buildEntityLookupMap,
+  findBestMatch,
+} from './ts-morph-parser.js';
+export type {
+  TsMorphEntity,
+  TsMorphRelationship,
+} from './ts-morph-parser.js';


### PR DESCRIPTION
## Summary

Exports ts-morph parser functions and types from `@code-graph/core` package to enable external integration.

## Changes

- Added exports to `packages/core/src/parser/index.ts`:
  - `parseProject` function for project-wide parsing
  - Helper functions: `extractEntities`, `extractRelationships`, `extractImportMap`, etc.
  - Types: `ProjectParseOptions`, `ProjectParseResult`, `TsMorphEntity`, `TsMorphRelationship`

- Re-exported ts-morph items from `packages/core/src/index.ts` for top-level access

## Exported Functions

- `parseProject`: Parse entire TypeScript/JavaScript projects with cross-file resolution
- `extractEntities`: Extract entities (functions, classes, types) from source files
- `extractRelationships`: Extract relationships (calls, extends, implements) with cross-file support
- `extractImportMap`: Build import symbol to file path mapping
- `extractVueScript`: Extract TypeScript content from Vue SFC files
- `extractJsDocContent`: Extract JSDoc documentation from declarations
- `buildEntityLookupMap`: Build entity lookup index for fast resolution
- `findBestMatch`: Resolve entity references using context-aware matching

## Exported Types

- `ProjectParseOptions`: Configuration for project parsing
- `ProjectParseResult`: Parse results with entities, relationships, and stats
- `TsMorphEntity`: Entity with ts-morph metadata (exported flag, JSDoc)
- `TsMorphRelationship`: Relationship with optional file paths for cross-file resolution

## Test Plan

- [x] All existing tests pass (659 tests)
- [x] TypeScript typecheck passes
- [x] No breaking changes to existing exports
- [x] Functions are importable from `@code-graph/core`

## Related Issue

Fixes #141

---

Generated with Claude Code