### PR TITLE
feat(mcp): integrate ts-morph into parse_directory for cross-file resolution

### DIFF
--- a/packages/core/src/graph/index.ts
+++ b/packages/core/src/graph/index.ts
@@ -4,3 +4,6 @@
 
 export { FileProcessor } from './file-processor.js';
 export type { ProcessFileOptions, ProcessFileResult } from './file-processor.js';
+
+export { TsMorphFileProcessor } from './ts-morph-file-processor.js';
+export type { ProcessProjectOptions, ProcessProjectResult } from './ts-morph-file-processor.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,8 +80,8 @@ export type {
 } from './db/index.js';
 
 // Graph exports
-export { FileProcessor } from './graph/index.js';
-export type { ProcessFileOptions, ProcessFileResult } from './graph/index.js';
+export { FileProcessor, TsMorphFileProcessor } from './graph/index.js';
+export type { ProcessFileOptions, ProcessFileResult, ProcessProjectOptions, ProcessProjectResult } from './graph/index.js';
 
 // Checkpoint exports
 export {


### PR DESCRIPTION
## Summary
- Integrate TsMorphFileProcessor into parse_directory tool for cross-file TypeScript/JavaScript relationship resolution
- Use ts-morph for TS/JS files (enables cross-file call tracking) while keeping tree-sitter for Ruby files
- Add relationship deduplication to prevent UNIQUE constraint violations

## Changes
- **packages/mcp-server/src/tools/parse-directory.ts**: Main integration - separates TS/JS files (processed with ts-morph) from Ruby files (processed with tree-sitter)
- **packages/core/src/graph/ts-morph-file-processor.ts**: Added deduplication logic for relationships to prevent database constraint errors
- **packages/core/src/graph/index.ts**: Export TsMorphFileProcessor
- **packages/core/src/index.ts**: Export TsMorphFileProcessor and types from @code-graph/core

## Test plan
- [x] All 688 tests pass
- [x] TypeScript/JavaScript cross-file relationships are captured
- [x] `what_calls` returns callers from other files
- [x] `what_does_call` returns callees in other files
- [x] Ruby parsing unchanged (uses tree-sitter)
- [x] No UNIQUE constraint violations on duplicate relationships

Closes #143

---
Generated with [Claude Code](https://claude.com/claude-code)