### PR TITLE
feat(parser): add progress callbacks to ts-morph project parser

### DIFF
--- a/packages/core/src/graph/ts-morph-file-processor.ts
+++ b/packages/core/src/graph/ts-morph-file-processor.ts
@@ -5,7 +5,7 @@ import {
   type NewRelationship,
   createRelationshipStore,
 } from '../db/relationships.js';
-import { parseProject, type ProjectParseResult, type ProgressCallback } from '../parser/ts-morph-project-parser.js';
+import { parseProject, type ProjectParseResult, type ProgressCallback, type FailedFile } from '../parser/ts-morph-project-parser.js';
 import type { TsMorphEntity, TsMorphRelationship } from '../parser/ts-morph-parser.js';
 
 /**
@@ -90,8 +90,11 @@ export interface ProcessProjectResult {
   relationships: Relationship[];
   success: boolean;
   error?: string;
+  /** Files that failed to load or parse */
+  failedFiles?: FailedFile[];
   stats?: {
     filesScanned: number;
+    filesLoaded: number;
     vueFilesProcessed: number;
     entitiesByType: Record<string, number>;
     relationshipsByType: Record<string, number>;
@@ -130,7 +133,7 @@ export class TsMorphFileProcessor {
       };
     }
 
-    const { entities: tsMorphEntities, relationships: tsMorphRelationships, stats } = parseResult;
+    const { entities: tsMorphEntities, relationships: tsMorphRelationships, stats, failedFiles } = parseResult;
 
     // Step 2: Build entity file path map for relationship enrichment
     // Map entity names to their file paths (for adding sourceFilePath to relationships)
@@ -289,6 +292,7 @@ export class TsMorphFileProcessor {
       entities: storedEntities,
       relationships: storedRelationships,
       success: true,
+      failedFiles,
       stats,
     };
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export type {
   ProjectParseOptions,
   ProjectParseResult,
   ProgressCallback,
+  FailedFile,
   TsMorphEntity,
   TsMorphRelationship,
 } from './parser/index.js';

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -40,6 +40,7 @@ export type {
   ProjectParseOptions,
   ProjectParseResult,
   ProgressCallback,
+  FailedFile,
 } from './ts-morph-project-parser.js';
 export {
   extractEntities,


### PR DESCRIPTION
## Summary

- Add `ProgressCallback` type with phases: scan, load, entities, relationships
- Add optional `onProgress` callback to `ProjectParseOptions`
- Call progress callback at each phase of parsing with current/total counts
- Pass progress callback through `TsMorphFileProcessor` to `parseProject`
- Wire up progress in `parse-directory` tool with throttling (100ms)
- Export `ProgressCallback` and `FailedFile` types from `@code-graph/core`

### Error Tracking Improvements

- Add `FailedFile` type to track files that fail to load/parse
- Include `failedFiles` array in `ProjectParseResult` and `ProcessProjectResult`
- Add `filesLoaded` count to stats (distinct from `filesScanned`)
- Report failed files in `parse-directory` tool output
- Add context to progress notification error logs (token, current, total)

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All 704 tests pass
- [x] Build succeeds

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)