### PR TITLE
fix(mcp-server): use correct metadata key in get_exports tool

### DIFF
--- a/packages/mcp-server/src/tools/__tests__/get-exports.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/get-exports.test.ts
@@ -44,7 +44,7 @@ describe('getExportsTool', () => {
       const db = getDatabase();
       const entityStore = createEntityStore(db);
 
-      // Create entity without isExported metadata
+      // Create entity without exported metadata
       entityStore.create({
         type: 'function',
         name: 'privateFunction',
@@ -80,7 +80,7 @@ describe('getExportsTool', () => {
         endLine: 15,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
           exportType: 'named',
           signature: '(name: string) => string',
         },
@@ -95,7 +95,7 @@ describe('getExportsTool', () => {
         endLine: 30,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
           exportType: 'named',
         },
       });
@@ -127,7 +127,7 @@ describe('getExportsTool', () => {
         endLine: 50,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
           exportType: 'default',
           signature: 'class Calculator { add(a: number, b: number): number }',
         },
@@ -159,7 +159,7 @@ describe('getExportsTool', () => {
         endLine: 100,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
           exportType: 'default',
         },
       });
@@ -173,7 +173,7 @@ describe('getExportsTool', () => {
         endLine: 110,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
           exportType: 'named',
         },
       });
@@ -186,7 +186,7 @@ describe('getExportsTool', () => {
         endLine: 112,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
           exportType: 'named',
         },
       });
@@ -216,7 +216,7 @@ describe('getExportsTool', () => {
         endLine: 5,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
         },
       });
 
@@ -248,7 +248,7 @@ describe('getExportsTool', () => {
       const db = getDatabase();
       const entityStore = createEntityStore(db);
 
-      // Private function (no isExported metadata)
+      // Private function (no exported metadata)
       entityStore.create({
         type: 'function',
         name: 'privateHelper',
@@ -267,11 +267,11 @@ describe('getExportsTool', () => {
         endLine: 15,
         language: 'typescript',
         metadata: {
-          isExported: true,
+          exported: true,
         },
       });
 
-      // Another private function (isExported: false)
+      // Another private function (exported: false)
       entityStore.create({
         type: 'function',
         name: 'anotherPrivate',
@@ -280,7 +280,7 @@ describe('getExportsTool', () => {
         endLine: 25,
         language: 'typescript',
         metadata: {
-          isExported: false,
+          exported: false,
         },
       });
 

--- a/packages/mcp-server/src/tools/get-exports.ts
+++ b/packages/mcp-server/src/tools/get-exports.ts
@@ -21,7 +21,7 @@ const getExportsInputSchema = z.object({
  * Get exports tool definition
  *
  * Retrieves all entities from a file and filters for those with
- * isExported metadata set to true.
+ * exported metadata set to true.
  */
 export const getExportsTool: ToolDefinition<typeof getExportsInputSchema> = {
   metadata: {
@@ -38,7 +38,7 @@ export const getExportsTool: ToolDefinition<typeof getExportsInputSchema> = {
 
     // Filter for exported entities
     const exports = entities.filter(
-      (e) => e.metadata?.['isExported'] === true
+      (e) => e.metadata?.['exported'] === true
     );
 
     // Format output


### PR DESCRIPTION
## Summary

- Fixed `get_exports` tool checking wrong metadata key (`isExported` instead of `exported`)
- Updated tests to use the correct metadata key

## Root Cause

The MCP `get_exports` tool was filtering entities using `metadata.isExported === true`, but the TypeScript extractor sets `metadata.exported`. This caused the tool to always return "no exports" even for files with exported entities.

## Changes

- `packages/mcp-server/src/tools/get-exports.ts`: Changed filter to check `exported` instead of `isExported`
- `packages/mcp-server/src/tools/__tests__/get-exports.test.ts`: Updated test fixtures to use correct key

## Test plan

- [x] Existing tests updated and passing
- [x] TypeCheck passes
- [x] Lint passes
- [x] Build passes
- [ ] Manual verification with real codebase (fobizz-rails)

Fixes part of #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)