### PR TITLE
feat(vue): Track template component usage as calls relationships

### DIFF
--- a/packages/core/src/graph/__tests__/file-processor.test.ts
+++ b/packages/core/src/graph/__tests__/file-processor.test.ts
@@ -653,7 +653,7 @@ describe('FileProcessor', () => {
         }
       });
 
-      it('supports what_calls queries for Vue components', async () => {
+      it('supports what_calls queries for Vue components', { timeout: 30000 }, async () => {
         // Process child first so it's in the database for cross-file resolution
         const childPath = join(fixturesDir, 'ChildComponent.vue');
         const childResult = await processor.processFile({ filePath: childPath, db });

--- a/packages/core/src/graph/__tests__/file-processor.test.ts
+++ b/packages/core/src/graph/__tests__/file-processor.test.ts
@@ -598,20 +598,88 @@ describe('FileProcessor', () => {
         const filePath = join(fixturesDir, 'sample-with-calls.vue');
         const result = await processor.processFile({ filePath, db });
 
-        // Vue file is processed successfully even though entity extraction
-        // for Vue is not yet implemented (future work).
+        // Vue file is processed successfully with entity extraction
         expect(result.success).toBe(true);
         expect(result.language).toBe('vue');
 
         // File entity is created
         const fileEntity = result.entities.find(e => e.type === 'file');
         expect(fileEntity).toBeDefined();
+      });
 
-        // Note: Call relationships from Vue script sections are extracted by the
-        // VueRelationshipExtractor, but they won't be stored because Vue entity
-        // extraction is not yet implemented. Once Vue entity extraction is added
-        // (tracking functions/methods in <script> sections), call relationships
-        // will be properly stored.
+      it('extracts Vue component entities', async () => {
+        const filePath = join(fixturesDir, 'ParentComponent.vue');
+        const result = await processor.processFile({ filePath, db });
+
+        expect(result.success).toBe(true);
+
+        // Should extract Vue component entity
+        const componentEntity = result.entities.find(e => e.type === 'class' && e.name === 'ParentComponent');
+        expect(componentEntity).toBeDefined();
+        expect(componentEntity?.language).toBe('vue');
+        expect(componentEntity?.metadata?.['exported']).toBe(true);
+      });
+
+      it('extracts template component usage as calls relationships', async () => {
+        // First process ChildComponent so it's in the database
+        const childPath = join(fixturesDir, 'ChildComponent.vue');
+        const childResult = await processor.processFile({ filePath: childPath, db });
+        expect(childResult.success).toBe(true);
+
+        // Then process ParentComponent which references ChildComponent
+        const parentPath = join(fixturesDir, 'ParentComponent.vue');
+        const parentResult = await processor.processFile({ filePath: parentPath, db });
+        expect(parentResult.success).toBe(true);
+
+        // Should extract ChildComponent usage in template as a calls relationship
+        const componentEntity = parentResult.entities.find(e => e.name === 'ParentComponent');
+        expect(componentEntity).toBeDefined();
+
+        if (componentEntity) {
+          const callRels = parentResult.relationships.filter(r =>
+            r.type === 'calls' && r.sourceId === componentEntity.id
+          );
+
+          // Should have a calls relationship to ChildComponent
+          const childComponentCall = callRels.find(r => {
+            const targetEntity = [...childResult.entities, ...parentResult.entities].find(
+              e => e.id === r.targetId
+            );
+            return targetEntity?.name === 'ChildComponent';
+          });
+
+          expect(childComponentCall).toBeDefined();
+          expect(childComponentCall?.metadata?.['usage']).toBe('template-component');
+        }
+      });
+
+      it('supports what_calls queries for Vue components', async () => {
+        // Process child first so it's in the database for cross-file resolution
+        const childPath = join(fixturesDir, 'ChildComponent.vue');
+        const childResult = await processor.processFile({ filePath: childPath, db });
+        expect(childResult.success).toBe(true);
+
+        // Then process parent which references child
+        const parentPath = join(fixturesDir, 'ParentComponent.vue');
+        const parentResult = await processor.processFile({ filePath: parentPath, db });
+        expect(parentResult.success).toBe(true);
+
+        // Query what calls ChildComponent
+        const relationshipStore = createRelationshipStore(db);
+        const childEntity = childResult.entities.find(e => e.name === 'ChildComponent');
+        expect(childEntity).toBeDefined();
+
+        if (childEntity) {
+          const callers = relationshipStore.findByTarget(childEntity.id);
+          const callRelationships = callers.filter(r => r.type === 'calls');
+
+          expect(callRelationships.length).toBeGreaterThan(0);
+
+          // Verify ParentComponent is one of the callers
+          const parentEntity = parentResult.entities.find(e => e.name === 'ParentComponent');
+          const parentCalls = callRelationships.find(r => r.sourceId === parentEntity?.id);
+          expect(parentCalls).toBeDefined();
+        }
       });
     });
   });

--- a/packages/core/src/graph/__tests__/fixtures/ChildComponent.vue
+++ b/packages/core/src/graph/__tests__/fixtures/ChildComponent.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="child">
+    <p>{{ message }}</p>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  message: String
+})
+</script>

--- a/packages/core/src/graph/__tests__/fixtures/ParentComponent.vue
+++ b/packages/core/src/graph/__tests__/fixtures/ParentComponent.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="parent">
+    <h1>{{ title }}</h1>
+    <ChildComponent :message="greeting" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import ChildComponent from './ChildComponent.vue'
+
+const title = ref('Parent Component')
+const greeting = ref('Hello from parent')
+</script>

--- a/packages/core/src/graph/file-processor.ts
+++ b/packages/core/src/graph/file-processor.ts
@@ -324,7 +324,7 @@ export class FileProcessor {
     }
     // Vue extraction
     else if (language === 'vue') {
-      const vueEntities = await this.extractVueEntities(node, filePath, language);
+      const vueEntities = await this.extractVueEntities(node, filePath);
       entities.push(...vueEntities);
     }
 
@@ -374,14 +374,9 @@ export class FileProcessor {
   /**
    * Extract Vue entities from AST using dedicated VueExtractor.
    */
-  private async extractVueEntities(
-    node: SyntaxNode,
-    filePath: string,
-    language: string
-  ): Promise<NewEntity[]> {
+  private async extractVueEntities(node: SyntaxNode, filePath: string): Promise<NewEntity[]> {
     const extractor = new VueExtractor({ filePath });
-    const extracted = await extractor.extract(node);
-    return extracted;
+    return extractor.extract(node);
   }
 
   /**

--- a/packages/core/src/parser/extractors/__tests__/vue-relationships.test.ts
+++ b/packages/core/src/parser/extractors/__tests__/vue-relationships.test.ts
@@ -141,6 +141,35 @@ import MyButton from './MyButton.vue'
       expect(buttonUsage?.targetFilePath).toBe('./MyButton.vue');
     });
 
+    it('resolves kebab-case component usage to PascalCase imports', async () => {
+      const code = `
+<template>
+  <div>
+    <my-button @click="handleClick" />
+  </div>
+</template>
+
+<script setup>
+import MyButton from './MyButton.vue'
+</script>
+      `;
+
+      const result = await parser.parse(code, 'vue');
+      if (!result.success) {
+        throw new Error('Parse failed');
+      }
+
+      const extractor = new VueRelationshipExtractor();
+      const relationships = await extractor.extract(result.result);
+
+      // Should detect my-button component usage with targetFilePath resolved from MyButton import
+      const buttonUsage = relationships.find(
+        (r) => r.targetName === 'my-button' && r.metadata?.['usage'] === 'template-component'
+      );
+      expect(buttonUsage).toBeDefined();
+      expect(buttonUsage?.targetFilePath).toBe('./MyButton.vue');
+    });
+
     it('ignores built-in HTML tags', async () => {
       const code = `
 <template>

--- a/packages/core/src/parser/extractors/__tests__/vue-relationships.test.ts
+++ b/packages/core/src/parser/extractors/__tests__/vue-relationships.test.ts
@@ -112,6 +112,35 @@ import CustomCard from './CustomCard.vue'
       expect(cardUsage).toBeDefined();
     });
 
+    it('adds targetFilePath for imported components', async () => {
+      const code = `
+<template>
+  <div>
+    <MyButton @click="handleClick" />
+  </div>
+</template>
+
+<script setup>
+import MyButton from './MyButton.vue'
+</script>
+      `;
+
+      const result = await parser.parse(code, 'vue');
+      if (!result.success) {
+        throw new Error('Parse failed');
+      }
+
+      const extractor = new VueRelationshipExtractor();
+      const relationships = await extractor.extract(result.result);
+
+      // Should detect MyButton component usage with targetFilePath
+      const buttonUsage = relationships.find(
+        (r) => r.targetName === 'MyButton' && r.metadata?.['usage'] === 'template-component'
+      );
+      expect(buttonUsage).toBeDefined();
+      expect(buttonUsage?.targetFilePath).toBe('./MyButton.vue');
+    });
+
     it('ignores built-in HTML tags', async () => {
       const code = `
 <template>

--- a/packages/core/src/parser/extractors/__tests__/vue-relationships.test.ts
+++ b/packages/core/src/parser/extractors/__tests__/vue-relationships.test.ts
@@ -102,7 +102,8 @@ import CustomCard from './CustomCard.vue'
         (r) => r.targetName === 'MyButton' && r.metadata?.['usage'] === 'template-component'
       );
       expect(buttonUsage).toBeDefined();
-      expect(buttonUsage?.sourceName).toBe('<template>');
+      expect(buttonUsage?.type).toBe('calls');
+      expect(buttonUsage?.sourceName).toBe('Component');
 
       // Should detect CustomCard component usage
       const cardUsage = relationships.find(

--- a/packages/core/src/parser/extractors/typescript-relationships.ts
+++ b/packages/core/src/parser/extractors/typescript-relationships.ts
@@ -8,6 +8,10 @@ export interface ExtractedRelationship {
   sourceName: string;
   sourceLocation?: { line: number; column: number };
   targetName: string;
+  /** File path where the target entity is defined (for cross-file resolution) */
+  targetFilePath?: string;
+  /** File path where the source entity is defined (for cross-file resolution) */
+  sourceFilePath?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/core/src/parser/extractors/vue.ts
+++ b/packages/core/src/parser/extractors/vue.ts
@@ -92,7 +92,8 @@ export class VueExtractor {
     const parseResult = await this.parser.parse(scriptContent, 'typescript');
     if (!parseResult.success) {
       console.warn(
-        `[VueExtractor] Failed to parse script in ${this.filePath}: ${parseResult.error.message}`
+        `[VueExtractor] Failed to parse script in ${this.filePath}: ${parseResult.error.message}. ` +
+          'Entity extraction will be incomplete for this file.'
       );
       return [];
     }
@@ -114,9 +115,10 @@ export class VueExtractor {
         endLine: entity.endLine + scriptStartLine,
       }));
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       console.warn(
-        `[VueExtractor] TypeScript extraction failed in ${this.filePath}:`,
-        error
+        `[VueExtractor] TypeScript extraction failed in ${this.filePath}: ${errorMessage}. ` +
+          'Entity extraction will be incomplete for this file.'
       );
       return [];
     }


### PR DESCRIPTION
## Summary

- Integrate VueExtractor in FileProcessor to create Vue component entities
- Change template component relationships from `imports` to `calls` type
- Add cross-file resolution via `targetFilePath` metadata
- Support kebab-case to PascalCase component name resolution

Fixes #168

## Changes

**FileProcessor** (`packages/core/src/graph/file-processor.ts`):
- Add `extractVueEntities()` method following Ruby pattern
- Call VueExtractor for `.vue` files in `extractEntities()`

**VueRelationshipExtractor** (`packages/core/src/parser/extractors/vue-relationships.ts`):
- Change relationship type from `imports` to `calls`
- Set `sourceName` to Vue component name (from filename) instead of `<template>`
- Build component import map to resolve template tags to file paths
- Add kebab-case to PascalCase conversion for template component resolution
- Improve error messages with file context

**ExtractedRelationship** (`packages/core/src/parser/extractors/typescript-relationships.ts`):
- Add `targetFilePath` and `sourceFilePath` optional properties

## Test plan

- [x] Vue component entities are extracted by FileProcessor
- [x] Template component usage creates `calls` relationships
- [x] `what_calls ChildComponent` returns ParentComponent
- [x] Kebab-case component tags resolve to PascalCase imports
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)