### PR TITLE
fix(mcp): deduplicate entities in query results by logical identity

### DIFF
--- a/packages/mcp-server/src/tools/__tests__/utils.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/utils.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import { deduplicateEntities, formatEntityList } from '../utils.js';
+import type { Entity } from '@code-graph/core';
+
+describe('deduplicateEntities', () => {
+  it('should return empty array for empty input', () => {
+    expect(deduplicateEntities([])).toEqual([]);
+  });
+
+  it('should return same entities when no duplicates', () => {
+    const entities: Entity[] = [
+      {
+        id: '1',
+        type: 'function',
+        name: 'func1',
+        filePath: '/file1.ts',
+        startLine: 1,
+        endLine: 10,
+        language: 'typescript',
+      },
+      {
+        id: '2',
+        type: 'function',
+        name: 'func2',
+        filePath: '/file2.ts',
+        startLine: 5,
+        endLine: 15,
+        language: 'typescript',
+      },
+    ];
+
+    const result = deduplicateEntities(entities);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.id).toBe('1');
+    expect(result[1]?.id).toBe('2');
+  });
+
+  it('should deduplicate entities with same name, file, and startLine', () => {
+    const entities: Entity[] = [
+      {
+        id: '1',
+        type: 'function',
+        name: 'duplicateFunc',
+        filePath: '/test.ts',
+        startLine: 10,
+        endLine: 20,
+        language: 'typescript',
+      },
+      {
+        id: '2', // Different ID
+        type: 'function',
+        name: 'duplicateFunc', // Same name
+        filePath: '/test.ts', // Same file
+        startLine: 10, // Same startLine
+        endLine: 20,
+        language: 'typescript',
+      },
+    ];
+
+    const result = deduplicateEntities(entities);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('1'); // Should keep first occurrence
+  });
+
+  it('should preserve order while deduplicating', () => {
+    const entities: Entity[] = [
+      {
+        id: 'first',
+        type: 'function',
+        name: 'alpha',
+        filePath: '/a.ts',
+        startLine: 1,
+        endLine: 5,
+        language: 'typescript',
+      },
+      {
+        id: 'duplicate-1',
+        type: 'function',
+        name: 'beta',
+        filePath: '/b.ts',
+        startLine: 1,
+        endLine: 5,
+        language: 'typescript',
+      },
+      {
+        id: 'third',
+        type: 'function',
+        name: 'gamma',
+        filePath: '/c.ts',
+        startLine: 1,
+        endLine: 5,
+        language: 'typescript',
+      },
+      {
+        id: 'duplicate-2',
+        type: 'function',
+        name: 'beta', // Duplicate of second
+        filePath: '/b.ts',
+        startLine: 1,
+        endLine: 5,
+        language: 'typescript',
+      },
+    ];
+
+    const result = deduplicateEntities(entities);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.name)).toEqual(['alpha', 'beta', 'gamma']);
+    expect(result[1]?.id).toBe('duplicate-1'); // First beta should be kept
+  });
+
+  it('should not deduplicate entities with same name but different file', () => {
+    const entities: Entity[] = [
+      {
+        id: '1',
+        type: 'function',
+        name: 'commonName',
+        filePath: '/file1.ts',
+        startLine: 1,
+        endLine: 10,
+        language: 'typescript',
+      },
+      {
+        id: '2',
+        type: 'function',
+        name: 'commonName',
+        filePath: '/file2.ts', // Different file
+        startLine: 1,
+        endLine: 10,
+        language: 'typescript',
+      },
+    ];
+
+    const result = deduplicateEntities(entities);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should not deduplicate entities with same name and file but different startLine', () => {
+    const entities: Entity[] = [
+      {
+        id: '1',
+        type: 'function',
+        name: 'overloadedFunc',
+        filePath: '/utils.ts',
+        startLine: 10,
+        endLine: 20,
+        language: 'typescript',
+      },
+      {
+        id: '2',
+        type: 'function',
+        name: 'overloadedFunc',
+        filePath: '/utils.ts',
+        startLine: 25, // Different startLine (e.g., function overload)
+        endLine: 35,
+        language: 'typescript',
+      },
+    ];
+
+    const result = deduplicateEntities(entities);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should handle multiple duplicates of the same entity', () => {
+    const entities: Entity[] = [
+      {
+        id: '1',
+        type: 'function',
+        name: 'multiDupe',
+        filePath: '/test.ts',
+        startLine: 5,
+        endLine: 15,
+        language: 'typescript',
+      },
+      {
+        id: '2',
+        type: 'function',
+        name: 'multiDupe',
+        filePath: '/test.ts',
+        startLine: 5,
+        endLine: 15,
+        language: 'typescript',
+      },
+      {
+        id: '3',
+        type: 'function',
+        name: 'multiDupe',
+        filePath: '/test.ts',
+        startLine: 5,
+        endLine: 15,
+        language: 'typescript',
+      },
+    ];
+
+    const result = deduplicateEntities(entities);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('1');
+  });
+});
+
+describe('formatEntityList', () => {
+  it('should deduplicate entities in output', () => {
+    const entities: Entity[] = [
+      {
+        id: '1',
+        type: 'function',
+        name: 'testFunc',
+        filePath: '/test.ts',
+        startLine: 1,
+        endLine: 10,
+        language: 'typescript',
+      },
+      {
+        id: '2',
+        type: 'function',
+        name: 'testFunc',
+        filePath: '/test.ts',
+        startLine: 1,
+        endLine: 10,
+        language: 'typescript',
+      },
+    ];
+
+    const output = formatEntityList(entities, {
+      title: 'Test Results:',
+      emptyMessage: 'No results',
+      itemLabel: 'entity',
+    });
+
+    expect(output).toContain('Total: 1 entity found');
+    expect(output).toContain('1. testFunc');
+    expect(output).not.toContain('2. testFunc');
+  });
+});

--- a/packages/mcp-server/src/tools/find-entity.ts
+++ b/packages/mcp-server/src/tools/find-entity.ts
@@ -111,9 +111,9 @@ export const findEntityTool: ToolDefinition<typeof findEntityInputSchema> = {
 
     const queryStr = queryParts.length > 0 ? `Query: ${queryParts.join(', ')}\n\n` : '';
 
-    // Format output using shared helper
+    // Format output using shared helper (handles deduplication internally)
     const listOutput = formatEntityList(entities, {
-      title: `Found ${entities.length.toString()} ${entities.length === 1 ? 'entity' : 'entities'}:`,
+      title: 'Results:',
       emptyMessage: 'No entities found.',
       itemLabel: 'entity',
     });


### PR DESCRIPTION
## Summary
- Adds deduplication to MCP tool query results to prevent duplicate entities from appearing
- Deduplicates by logical identity tuple: (name, filePath, startLine)
- Fixes pluralization for words ending in 'y' (entity -> entities)

## Problem
Same entities (e.g., ApplicationController methods) were appearing multiple times in query results when duplicate entities exist in the database from multiple parse operations.

## Solution
Added a `deduplicateEntities` utility function that filters entities by their logical identity before formatting output. This is applied in `formatEntityList` which is used by all MCP query tools.

## Test plan
- [x] Added unit tests for `deduplicateEntities` function
- [x] Added integration test for `find_entity` with duplicates
- [x] Added integration test for `what_calls` with duplicates
- [x] All existing tests pass

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)