### PR TITLE
fix(ruby): support namespaced class lookups

### DIFF
--- a/packages/core/src/db/__tests__/entities.test.ts
+++ b/packages/core/src/db/__tests__/entities.test.ts
@@ -504,4 +504,81 @@ describe('EntityStore', () => {
       expect(results).toHaveLength(2);
     });
   });
+
+  describe('namespaced class lookups', () => {
+    beforeEach(() => {
+      // Create a namespaced class with shortName in metadata
+      store.create({
+        type: 'class',
+        name: 'Tools::SchoolClass',
+        filePath: '/app/models/tools/school_class.rb',
+        startLine: 1,
+        endLine: 50,
+        language: 'ruby',
+        metadata: {
+          shortName: 'SchoolClass',
+          namespace: 'Tools',
+        },
+      });
+
+      // Create a top-level class without namespace
+      store.create({
+        type: 'class',
+        name: 'User',
+        filePath: '/app/models/user.rb',
+        startLine: 1,
+        endLine: 30,
+        language: 'ruby',
+      });
+    });
+
+    it('findByName finds class by qualified name', () => {
+      const results = store.findByName('Tools::SchoolClass');
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('Tools::SchoolClass');
+    });
+
+    it('findByName finds class by short name', () => {
+      const results = store.findByName('SchoolClass');
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('Tools::SchoolClass');
+    });
+
+    it('findEntity with exact match finds by qualified name', () => {
+      const results = store.findEntity({ namePattern: 'Tools::SchoolClass', matchMode: 'exact' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('Tools::SchoolClass');
+    });
+
+    it('findEntity with exact match finds by short name', () => {
+      const results = store.findEntity({ namePattern: 'SchoolClass', matchMode: 'exact' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('Tools::SchoolClass');
+    });
+
+    it('findEntity with prefix match finds by short name prefix', () => {
+      const results = store.findEntity({ namePattern: 'School', matchMode: 'prefix' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('Tools::SchoolClass');
+    });
+
+    it('findEntity with contains match finds by short name substring', () => {
+      const results = store.findEntity({ namePattern: 'Class', matchMode: 'contains' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('Tools::SchoolClass');
+    });
+
+    it('top-level classes without shortName are still findable', () => {
+      const results = store.findByName('User');
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.name).toBe('User');
+    });
+  });
 });

--- a/packages/core/src/parser/extractors/__tests__/ruby.test.ts
+++ b/packages/core/src/parser/extractors/__tests__/ruby.test.ts
@@ -340,7 +340,7 @@ describe('RubyExtractor', () => {
   });
 
   describe('nested structures', () => {
-    it('extracts class inside module', async () => {
+    it('extracts class inside module with qualified name', async () => {
       const code = `
         module Namespace
           class Calculator
@@ -360,7 +360,13 @@ describe('RubyExtractor', () => {
       expect(modules[0]?.name).toBe('Namespace');
 
       expect(classes).toHaveLength(1);
-      expect(classes[0]?.name).toBe('Calculator');
+      // Class name is now fully qualified
+      expect(classes[0]?.name).toBe('Namespace::Calculator');
+      // Short name is stored in metadata for searching
+      expect(classes[0]?.metadata).toEqual({
+        shortName: 'Calculator',
+        namespace: 'Namespace',
+      });
 
       expect(methods).toHaveLength(1);
       expect(methods[0]?.name).toBe('Namespace::Calculator#add');


### PR DESCRIPTION
## Summary
- Searching for `SchoolClass` now finds `Tools::SchoolClass`
- Both qualified and short names work for lookups
- Store short name in metadata for searching

## Problem
Searching for `Tools::SchoolClass` returned nothing - had to use just `SchoolClass`. This made it difficult to find namespaced Ruby classes.

## Solution
1. Ruby extractor now stores classes/modules with fully qualified names (`Tools::SchoolClass`)
2. Short name (`SchoolClass`) and namespace (`Tools`) stored in metadata
3. `findByName` and `findEntity` updated to search both `name` and `metadata.shortName`

This allows searching by either the full qualified name or just the short name.

## Test plan
- [x] Added unit tests for namespaced class lookups via `findByName`
- [x] Added unit tests for namespaced lookups via `findEntity` (exact, prefix, contains modes)
- [x] Updated Ruby extractor tests to verify qualified names are stored
- [x] All existing tests pass

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)